### PR TITLE
tests: cover error handling code paths

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Test
 using ArgTools
 
+## example test function ##
+
 function send_data(src::ArgRead, dst::Union{ArgWrite, Nothing} = nothing)
     arg_read(src) do src_io
         arg_write(dst) do dst_io
@@ -13,7 +15,7 @@ function send_data(src::ArgRead, dst::Union{ArgWrite, Nothing} = nothing)
     end
 end
 
-@testset "ArgTools.jl" begin
+@testset "main API" begin
     # create a source file
     src_file = tempname()
     data = rand(UInt8, 666)
@@ -63,4 +65,29 @@ end
 
     # cleanup
     rm(src_file)
+end
+
+## for testing error handling ##
+
+struct ErrIO <: IO end
+
+Base.eof(::ErrIO) = false
+Base.write(::ErrIO, ::UInt8) = error("boom")
+Base.read(::ErrIO, ::Type{UInt8}) = error("bam")
+
+import Base.Filesystem: TEMP_CLEANUP, temp_cleanup_purge
+
+@testset "error cleanup" begin
+    @testset "arg_write(path)" begin
+        dst = tempname()
+        @test_throws ErrorException send_data(ErrIO(), dst)
+        @test !isfile(dst)
+    end
+    @testset "arg_write(nothing)" begin
+        temp_cleanup_purge(false)
+        @test length(TEMP_CLEANUP) == 0
+        @test_throws ErrorException send_data(ErrIO())
+        @test length(TEMP_CLEANUP) == 1
+        @test !ispath(first(keys(TEMP_CLEANUP)))
+    end
 end


### PR DESCRIPTION
This PR increases code coverage by testing error-only code paths when `path` or `nothing` are passed to `arg_write`.